### PR TITLE
Include additional bot commands

### DIFF
--- a/packages/bot/src/commands/index.ts
+++ b/packages/bot/src/commands/index.ts
@@ -1,8 +1,12 @@
 import { CommandMap } from './command.js';
+import { configCommand } from './config.js';
 import { leaderboardCommand } from './leaderboard.js';
 import { linkTwitterCommand } from './link-twitter.js';
+import { multipliersCommand } from './multipliers.js';
 import { pointsCommand } from './points.js';
+import { questCommand } from './quest.js';
 import { redeemCommand } from './redeem.js';
+import { rewardsCommand } from './rewards.js';
 import { walletCommand } from './wallet.js';
 
 export const commands = [
@@ -11,6 +15,10 @@ export const commands = [
   pointsCommand,
   leaderboardCommand,
   redeemCommand,
+  configCommand,
+  multipliersCommand,
+  questCommand,
+  rewardsCommand,
 ];
 
 export const commandMap: CommandMap = new Map(commands.map((command) => [command.data.name, command]));


### PR DESCRIPTION
## Summary
- add config, multipliers, quest, and rewards commands to the exported command list
- keep the command map and registration script using the full command array

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68daf4402d5883289736b84aa6474b85